### PR TITLE
Multiple Placeholder Image Generation

### DIFF
--- a/multiple-placeholders-template.json
+++ b/multiple-placeholders-template.json
@@ -1,0 +1,12 @@
+{
+  "images": [
+    {
+      "title": "banner",
+      "width": 1200,
+      "height": 320
+    },
+    {
+      "height": 80
+    }
+  ]
+}


### PR DESCRIPTION
Allow user to specify multiple placeholders to be generated using a JSON format.

Fixes #57 

Allow multiple placeholder images to be generated

- Uses the JSON format specified in #57
- If no title is present generates a title based on image dimensions
- If no dimension is specified it will use the default 800 pixels
- Template JSON file provided to show use
